### PR TITLE
:bug: change to cluster issuer

### DIFF
--- a/k8s/template/ingress.yml
+++ b/k8s/template/ingress.yml
@@ -5,7 +5,7 @@ metadata:
   namespace: $NAMESPACE
   annotations:
     kubernetes.io/ingress.class: nginx
-    cert-manager.io/issuer: "letsencrypt-production"
+    cert-manager.io/cluster-issuer: "letsencrypt-production"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/cors-allow-headers: "authorization,content-type"


### PR DESCRIPTION
K8s deployment is invalid because there is no issuer available in new namespace "support-pp". Changing to fallback `ClusterIssuer` fix this bug. 